### PR TITLE
V1.9.4

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,19 +1,36 @@
 # Release Notes
 
+## v1.9.4 (2019-12-14)
+
+### Fixed
+- Color of the element `code.parameter` on https://www.php.net/manual/en/datetime.createfromformat.php page
+- Link in `src/readme.txt` file
+
+### Added
+- Line separators between changes in changelog.ml file
+
+----
+
 ## v1.9.3 (2019-12-14)
 
 ### Fixed
 - Method name color on page https://www.php.net/manual/en/datetime.createfromformat.php
+
+----
 
 ## v1.9.2 (2019-12-12)
 
 ### Added
 - Styles for page: https://www.php.net/downloads.php
 
+----
+
 ## v1.9.1 (2019-12-07)
 
 ### Fixed
 - Changed styles of "add comment" button on function page.
+
+----
 
 ## v1.9 (2019-12-07)
 
@@ -22,6 +39,8 @@
 
 ### Fixed
 - "Add comment" button on function page now has white color
+
+----
 
 ## v1.8 (2019-09-02)
 

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 - Color of the element `code.parameter` on https://www.php.net/manual/en/datetime.createfromformat.php page
+- Colors for class properties on pages like https://www.php.net/manual/en/class.arithmeticerror.php
 - Link in `src/readme.txt` file
 
 ### Added

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
 ### Fixed
 - Color of the element `code.parameter` on https://www.php.net/manual/en/datetime.createfromformat.php page
 - Colors for class properties on pages like https://www.php.net/manual/en/class.arithmeticerror.php
+- Styles for chrome browser for php class pages
 - Link in `src/readme.txt` file
 
 ### Added

--- a/resources/sass/_table-doctable.sass
+++ b/resources/sass/_table-doctable.sass
@@ -18,6 +18,9 @@ table.doctable
                 color: white
                 font-weight: normal
 
+                code.parameter
+                    color: $light-color
+
     tbody
         td
             vertical-align: middle

--- a/resources/sass/function-page/code/_class-params.sass
+++ b/resources/sass/function-page/code/_class-params.sass
@@ -1,8 +1,8 @@
 .partintro .classsynopsis
-    background: #313542
-    border-radius: 4px
-    border: none
-    color: #b6d3f0
+    background: #313542 !important
+    border-radius: 4px !important
+    border: none !important
+    color: #b6d3f0 !important
 
     // Properties
     .varname a,
@@ -14,7 +14,7 @@
     .ooclass .classname,
     .oointerface .interfacename a,
         color: #ffc06b !important
-        border-bottom: none
+        border-bottom: none !important
 
     // Keywords like public, private
     .methodsynopsis .modifier,

--- a/resources/sass/function-page/code/_class-params.sass
+++ b/resources/sass/function-page/code/_class-params.sass
@@ -4,6 +4,11 @@
     border: none
     color: #b6d3f0
 
+    // Properties
+    .varname a,
+    .varname var
+        color: #acbff5 !important
+
     // CLass call and class name
     .ooclass strong,
     .ooclass .classname,

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 2,
     "name": "PHP Revival",
-    "version": "1.9.3",
+    "version": "1.9.4",
     "web_accessible_resources": [
         "images/*"
     ],

--- a/src/readme.txt
+++ b/src/readme.txt
@@ -1,1 +1,1 @@
-Source code is on Github https://github.com/SerhiiCho/php_revival
+All the source code is on Github https://github.com/SerhiiCho/php-revival


### PR DESCRIPTION
## v1.9.4 (2019-12-14)

### Fixed
- Color of the element `code.parameter` on https://www.php.net/manual/en/datetime.createfromformat.php page
- Colors for class properties on pages like https://www.php.net/manual/en/class.arithmeticerror.php
- Styles for chrome browser for php class pages
- Link in `src/readme.txt` file

### Added
- Line separators between changes in changelog.ml file